### PR TITLE
Leading WS and NL characters cause parsers to fail

### DIFF
--- a/test/grammar_features/input_with_leading_space_or_newline_characters.spec.js
+++ b/test/grammar_features/input_with_leading_space_or_newline_characters.spec.js
@@ -2,13 +2,13 @@ import { compileGrammarSource } from "../tools.js";
 
 assert_group(sequence, 10000, () => {
 
-    const grammar = `@IGNORE g:ws \n <> A > A g:id f:r{ $sym1 + " " + $sym2} \n | g:id`;
+    const grammar = `@IGNORE g:ws g:nl \n <> A > A g:id f:r{ $sym1 + " " + $sym2} \n | g:id`;
 
     const parser = await compileGrammarSource(grammar);
 
     assert("Construct test parser", parser != undefined);
 
-    const input = `   TEST TEST TEST TEST`;
+    const input = `   \nTEST TEST TEST TEST`;
 
     assert("Parse of input is successful", parser(input).FAILED == false);
 

--- a/test/grammar_features/input_with_leading_space_or_newline_characters.spec.js
+++ b/test/grammar_features/input_with_leading_space_or_newline_characters.spec.js
@@ -1,0 +1,17 @@
+import { compileGrammarSource } from "../tools.js";
+
+assert_group(sequence, 10000, () => {
+
+    const grammar = `@IGNORE g:ws \n <> A > A g:id f:r{ $sym1 + " " + $sym2} \n | g:id`;
+
+    const parser = await compileGrammarSource(grammar);
+
+    assert("Construct test parser", parser != undefined);
+
+    const input = `   TEST TEST TEST TEST`;
+
+    assert("Parse of input is successful", parser(input).FAILED == false);
+
+    assert("Parse of input produces expected value", parser(input).result[0] == "TEST TEST TEST TEST");
+
+});


### PR DESCRIPTION
Fix issue identified in #5